### PR TITLE
Add sourcemap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ important properties:
   node code and not a module inside the node_modules directory)
 - `callsite.isModule()` - Is this inside the node_modules directory?
 - `callsite.isNode()` - Is this inside node core?
+- `callsite.getSourceMappedFileName()` - If this function was defined in a script
+  which includes a source map reference, returns the name of the original script.
+  If a source map doesn't exist, it aliases `getFileName()`
+- `callsite.getSourceMappedLineNumber()` - If this function was defined in a
+  script which includes a source map reference, returns the current line
+  number of the original script. If a source map doesn't exist,
+  it aliases `getLineNumber()`
+- `callsite.getSourceMappedColumnNumber()` - If this function was defined in a
+  script which includes a source map reference, returns the current column
+  number of the original script. If a source map doesn't exist,
+  it aliases `getColumnNumber()`
 
 #### Methods inherited from V8
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "error-callsites": "^1.0.1",
     "lru-cache": "^4.0.1",
     "path-is-absolute": "^1.0.1",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "sourcemap-decorate-callsites": "^1.0.0"
   },
   "devDependencies": {
     "longjohn": "=0.2.9",
@@ -45,5 +46,10 @@
   "coordinates": [
     55.6809887,
     12.5643973
-  ]
+  ],
+  "standard": {
+    "ignore": [
+      "/test/fixtures/"
+    ]
+  }
 }

--- a/test/fixtures/generateError.js
+++ b/test/fixtures/generateError.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Just a little prefixing line
+var generateError = function generateError() {
+  var errMessage = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'Some error';
+  return new Error(errMessage);
+};
+
+module.exports = generateError;
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4vZ2VuZXJhdGVFcnJvci5vcmlnaW5hbC5qcyJdLCJuYW1lcyI6WyJnZW5lcmF0ZUVycm9yIiwiZXJyTWVzc2FnZSIsIkVycm9yIiwibW9kdWxlIiwiZXhwb3J0cyJdLCJtYXBwaW5ncyI6Ijs7QUFBQTtBQUNBLElBQU1BLGdCQUFnQixTQUFoQkEsYUFBZ0I7QUFBQSxNQUFDQyxVQUFELHVFQUFjLFlBQWQ7QUFBQSxTQUErQixJQUFJQyxLQUFKLENBQVVELFVBQVYsQ0FBL0I7QUFBQSxDQUF0Qjs7QUFFQUUsT0FBT0MsT0FBUCxHQUFpQkosYUFBakIiLCJmaWxlIjoiZ2VuZXJhdGVFcnJvci5qcyIsInNvdXJjZXNDb250ZW50IjpbIi8vIEp1c3QgYSBsaXR0bGUgcHJlZml4aW5nIGxpbmVcbmNvbnN0IGdlbmVyYXRlRXJyb3IgPSAoZXJyTWVzc2FnZSA9ICdTb21lIGVycm9yJykgPT4gbmV3IEVycm9yKGVyck1lc3NhZ2UpXG5cbm1vZHVsZS5leHBvcnRzID0gZ2VuZXJhdGVFcnJvclxuIl19

--- a/test/fixtures/generateError.original.js
+++ b/test/fixtures/generateError.original.js
@@ -1,0 +1,4 @@
+// Just a little prefixing line
+const generateError = (errMessage = 'Some error') => new Error(errMessage)
+
+module.exports = generateError


### PR DESCRIPTION
Top o' the morning to you!

I've been toying with getting Opbeat to report sourcemapped locations for errors over the weekend. It's been a bit of a rough ride, and I'm not sure this is the best way of solving it, but I thought I'd open a PR for discussion, at least.

Basically, I've made a module ([sourcemap-decorate-callsites](https://github.com/rexxars/sourcemap-decorate-callsites)) which takes a stack of callsites returned by [error-callsites](https://github.com/watson/error-callsites) and decorates them with sourcemap file/line/column getter functions.

Originally I intended to just integrate this functionality into either stackman or error-callsites, but having to support both sync and async and due to the nature of having to read various files, extract locations and instantiate sourcemap consumers, it turned out to be a bit of code that would significantly enlarge either module. If you'd rather see this functionality added directly into either of these modules, let me know.

I figured it would be nice to expose some additional methods from stackman which can return these locations if present, and if not gracefully fall back to non-sourcemapped locations. Again something I'm a little unsure of - one could argue it would be better to return `undefined` or `null` if no sourcemap is found, and have the user call `getSourceMappedLineNumber() || getLineNumber()` where applicable. Thoughts welcome, as with everything else.

Lastly, I've made use of these functions to extract the context object. This seems to work fairly well.

There's a multitude of things to discuss here, obviously. Perhaps we should only attempt to extract source maps if you pass a `sourcemaps` option, for instance, but that opens questions on whether the source map getter functions should be present in that case, or not.

Regardless of all my questions and doubts on how to best implement it, it does seem to work. With a [simple change in opbeat-node](https://github.com/rexxars/opbeat-node/commit/4bc4633324a25f82f04a2fee7a0a8bf48833b88b) paired with these changes in stackman, opbeat logs sourcemapped locations. 

Feedback and thoughts are very welcome.
