### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ module.exports = function stackman (opts) {
   })
 
   return {
-    callsites: callsites,
-    properties: properties,
-    sourceContexts: sourceContexts
+    callsites,
+    properties,
+    sourceContexts
   }
 
   function callsites (err, opts, cb) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166