### PR TITLE
Document minimum supported Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "ignore": [
       "/test/fixtures/lib/"
     ]
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
This is nice to have documented so that we know which syntax that is available, and which version of standard that can be used.

(ref: https://github.com/standard/eslint-config-standard/pull/166)