### PR TITLE
fix: support file:// protocol seen in node14 ESM modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ module.exports = function stackman (opts) {
       properties.getFileName = {
         writable: true,
         value: function () {
-          var filename = getFileName.call(callsite)
+          var filename = getFileName.call(callsite).replace(/^file:\/\//, '')
           var sourceFile = getPosition().source
           if (!sourceFile) return filename
           var sourceDir = path.dirname(filename)
@@ -301,6 +301,13 @@ module.exports = function stackman (opts) {
         writable: true,
         value: function () {
           return getPosition().column || getColumnNumber.call(callsite)
+        }
+      }
+    } else {
+      properties.getFileName = {
+        writable: true,
+        value: function () {
+          return getFileName.call(callsite).replace(/^file:\/\//, '')
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "tape": "^4.13.2"
   },
   "scripts": {
-    "test": "standard && node test/strict.js && node test/non-strict.js && node test/longjohn.js && node test/sourcemap.js"
+    "test": "node test/strict.js && node test/non-strict.js && node test/longjohn.js && node test/sourcemap.js && node test/esm.mjs",
+    "posttest": "npm run lint",
+    "lint": "standard"
   },
   "repository": {
     "type": "git",

--- a/test/esm.mjs
+++ b/test/esm.mjs
@@ -1,0 +1,32 @@
+import test from 'tape'
+import createStackman from '../index.js'
+
+const stackman = createStackman()
+
+test('callsite.getRelativeFileName()', function (t) {
+  var err = new Error('foo')
+  stackman.callsites(err, function (err, callsites) {
+    t.error(err)
+    t.equal(callsites[0].getRelativeFileName(), 'test/esm.mjs')
+    t.end()
+  })
+})
+
+test('callsite.sourceContext()', function (t) {
+  var err = new Error()
+  stackman.callsites(err, function (err, callsites) {
+    t.error(err)
+
+    callsites[0].sourceContext(function (err, context) {
+      t.error(err)
+      t.equal(typeof context, 'object')
+      t.equal(typeof context.line, 'string')
+      t.ok(Array.isArray(context.pre), 'should be an array')
+      t.ok(Array.isArray(context.post), 'should be an array')
+      t.equal(context.pre.length, 2)
+      t.equal(context.post.length, 2)
+      t.equal(context.line.trim(), 'var err = new Error()')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Hi! I've been testing ESM support for a work project, and noticed that filenames in stack traces were prefixed by `file://`. As a result, `getSourceContext` would return empty results, while `getRelativeFileName` was unable to properly truncate the filename. This change appears to fix the issue.

I've added some pretty bare-bones tests to assert that the change works. I rearranged `package.json` a bit to get it to work (moving `standard` to `npm run lint`, run as a `posttest` command) but please discard that change if it's not your cup of tea!